### PR TITLE
DoomRater bug fix #2

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemReachRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemReachRing.java
@@ -25,7 +25,7 @@ public class ItemReachRing extends ItemBaubleModifier {
 
 	@Override
 	void fillModifiers(Multimap<String, AttributeModifier> attributes, ItemStack stack) {
-		attributes.put(EntityPlayer.REACH_DISTANCE.getName(), new AttributeModifier(getBaubleUUID(stack), "Reach Ring", 3.5, 0).setSaved(false));
+		attributes.put(EntityPlayer.REACH_DISTANCE.getName(), new AttributeModifier(getBaubleUUID(stack), "Reach Ring", 3.5, AttributeModifier.Operation.ADDITION));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemReachRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemReachRing.java
@@ -25,7 +25,7 @@ public class ItemReachRing extends ItemBaubleModifier {
 
 	@Override
 	void fillModifiers(Multimap<String, AttributeModifier> attributes, ItemStack stack) {
-		attributes.put(EntityPlayer.REACH_DISTANCE.getName(), new AttributeModifier(getBaubleUUID(stack), "Reach Ring", 3.5, AttributeModifier.Operation.ADDITION));
+		attributes.put(EntityPlayer.REACH_DISTANCE.getName(), new AttributeModifier(getBaubleUUID(stack), "Reach Ring", 3.5, 0));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
@@ -105,7 +105,7 @@ public class ItemOdinRing extends ItemRelicBauble {
 		if(stack.isEmpty()) // workaround for Azanor/Baubles#156
 			return;
 		
-		attributes.put(SharedMonsterAttributes.MAX_HEALTH.getName(), new AttributeModifier(getBaubleUUID(stack), "Odin Ring", 20, AttributeModifier.Operation.ADDITION));
+		attributes.put(SharedMonsterAttributes.MAX_HEALTH.getName(), new AttributeModifier(getBaubleUUID(stack), "Odin Ring", 20, 0));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
@@ -105,7 +105,7 @@ public class ItemOdinRing extends ItemRelicBauble {
 		if(stack.isEmpty()) // workaround for Azanor/Baubles#156
 			return;
 		
-		attributes.put(SharedMonsterAttributes.MAX_HEALTH.getName(), new AttributeModifier(getBaubleUUID(stack), "Odin Ring", 20, 0).setSaved(false));
+		attributes.put(SharedMonsterAttributes.MAX_HEALTH.getName(), new AttributeModifier(getBaubleUUID(stack), "Odin Ring", 20, AttributeModifier.Operation.ADDITION));
 	}
 
 	@Override


### PR DESCRIPTION
So, the hearts being lost on relog was an actual bug huh?  Time to commit that bugfix to 1.12.2, this is a headache every time I lose connection to the server.  I also get to test what's going on with that reach ring, because I can't recall if that was an actual problem or not.  Hopefully I didn't just replicate the old stacking reach ring bug.