### PR TITLE
Attempt to fix ghosting items

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
@@ -56,7 +56,7 @@ public class ItemTerrasteelHelm extends ItemTerrasteelArmor implements IManaDisc
 	@Override
 	public void onArmorTick(World world, EntityPlayer player, ItemStack stack) {
 		super.onArmorTick(world, player, stack);
-		if(hasArmorSet(player)) {
+		if(!world.isRemote && hasArmorSet(player)) {
 			int food = player.getFoodStats().getFoodLevel();
 			if(food > 0 && food < 18 && player.shouldHeal() && player.ticksExisted % 80 == 0)
 				player.heal(1F);

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemAuraRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemAuraRing.java
@@ -31,7 +31,7 @@ public class ItemAuraRing extends ItemBauble implements IManaGivingItem {
 	@Override
 	public void onWornTick(ItemStack stack, EntityLivingBase player) {
 		super.onWornTick(stack, player);
-		if(player instanceof EntityPlayer && player.ticksExisted % getDelay() == 0)
+		if(!player.world.isRemote && player instanceof EntityPlayer && player.ticksExisted % getDelay() == 0)
 			ManaItemHandler.dispatchManaExact(stack, (EntityPlayer) player, 1, true);
 	}
 


### PR DESCRIPTION
Mana using items get updated both client side and server side by mana handlers right now, and the result is a lot of ghosted items.  By only updating server side, and letting client sync, these ghost items should no longer generate, which will result in fewer inventory desyncs and should also disable flugel tiara flight clientside when there's no actual mana source available.

Only two files needed updating here.